### PR TITLE
Make Reference Strings Unique

### DIFF
--- a/src/agents.py
+++ b/src/agents.py
@@ -31,7 +31,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from unicodedata import normalize
 from src.enums import Bible
 from src.enums import Bible_Books
 from src.enums import Reverse_Bible_Books

--- a/src/api.py
+++ b/src/api.py
@@ -230,4 +230,3 @@ class API:
             ans = passage.show()
         else:
             ans = self.passage.show()
-

--- a/src/enums.py
+++ b/src/enums.py
@@ -64,8 +64,8 @@ if not CACHE_DIR.exists():
 if not DATA_DIR.exists():
     DATA_DIR.mkdir(parents=True)
 
-license_text = """
-scripture_phaser helps you to memorize the Bible.
+license_text = \
+"""scripture_phaser helps you to memorize the Bible.
 Copyright (C) 2023-2024 Nolan McMahon
 
 scripture_phaser is licensed under the terms of the BSD 3-Clause License
@@ -94,8 +94,7 @@ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
-"""
+POSSIBILITY OF SUCH DAMAGE."""
 
 
 class TermColours:

--- a/src/reference.py
+++ b/src/reference.py
@@ -47,88 +47,37 @@ class Reference:
 
             self.book_start, self.chapter_start, self.verse_start, \
             self.book_end, self.chapter_end, self.verse_end = \
-                self.interpret_reference(self.clean_reference(reference))
+                self.interpret_reference(reference)
 
             self.ref_str = self.standardize_reference()
 
     @staticmethod
-    def convert_numbered_books(ref, digit_to_alpha):
-        if digit_to_alpha:
-            ref = ref \
-                .replace("1 Samuel", "One Samuel") \
-                .replace("1 Kings", "One Kings") \
-                .replace("1 Chronicles", "One Chronicles") \
-                .replace("1 Corinthians", "One Corinthians") \
-                .replace("1 Thessalonians", "One Thessalonians") \
-                .replace("1 Timothy", "One Timothy") \
-                .replace("1 Peter", "One Peter") \
-                .replace("1 John", "One John") \
-                .replace("2 Samuel", "Two Samuel") \
-                .replace("2 Kings", "Two Kings") \
-                .replace("2 Chronicles", "Two Chronicles") \
-                .replace("2 Corinthians", "Two Corinthians") \
-                .replace("2 Thessalonians", "Two Thessalonians") \
-                .replace("2 Timothy", "Two Timothy") \
-                .replace("2 Peter", "Two Peter") \
-                .replace("2 John", "Two John") \
-                .replace("3 John", "Three John")
-        else:
-            ref = ref \
-                .replace("One", "1") \
-                .replace("Two", "2") \
-                .replace("Three", "3")
-        
-        return ref
-
-    @classmethod
-    def clean_reference(cls, ref):
-        ref = " ".join(ref.split()) # Multiple Whitespaces -> One Whitespace
-        ref = ref.strip().lower().title()
-
-        ref = cls.convert_numbered_books(ref, digit_to_alpha=True)
+    def reference_replacements(ref):
         # Replace "Psalm" -> "Psalms" will also turn "Psalms" -> "Psalmss"
         ref = ref \
             .replace(".", "") \
             .replace("Psalm", "Psalms") \
+            .replace("Psalmss", "Psalms") \
             .replace("First", "One") \
             .replace("Second", "Two") \
             .replace("Third", "Three") \
-            .replace("Psalmss", "Psalms")
-
-        new_ref = ""
-        prev_char = ""
-        for i, char in enumerate(ref):
-            next_char = ref[min(len(ref)-1, i+1)]
-            # Insert Space After Book Name and Before Chapter/Verse Number
-            if char.isdigit() and prev_char.isalpha():
-                new_ref += " "
-
-            # Insert Space After Verse Number and Before Second Book Name
-            elif char.isalpha() and prev_char.isdigit():
-                new_ref += " "
-
-            # Insert Space Between Number and "-"
-            elif char == "-" and prev_char != " " and prev_char != "":
-                new_ref += " "
-
-            # Insert Space Between "-" and Number/Book
-            elif prev_char == "-" and char != " ":
-                new_ref += " "
-
-            elif char == " ":
-                # Remove Space Before ":" and After Chapter Number
-                if prev_char.isdigit() and next_char == ":":
-                    prev_char = ref[max(0, i)]
-                    continue
-                # Remove Space After ":" and Before Verse Number
-                elif prev_char == ":" and next_char.isdigit():
-                    prev_char = ref[max(0, i)]
-                    continue
-
-            prev_char = ref[max(0, i)]
-            new_ref += ref[i]
-
-        new_ref = new_ref \
+            .replace("1 Samuel", "One Samuel") \
+            .replace("1 Kings", "One Kings") \
+            .replace("1 Chronicles", "One Chronicles") \
+            .replace("1 Corinthians", "One Corinthians") \
+            .replace("1 Thessalonians", "One Thessalonians") \
+            .replace("1 Timothy", "One Timothy") \
+            .replace("1 Peter", "One Peter") \
+            .replace("1 John", "One John") \
+            .replace("2 Samuel", "Two Samuel") \
+            .replace("2 Kings", "Two Kings") \
+            .replace("2 Chronicles", "Two Chronicles") \
+            .replace("2 Corinthians", "Two Corinthians") \
+            .replace("2 Thessalonians", "Two Thessalonians") \
+            .replace("2 Timothy", "Two Timothy") \
+            .replace("2 Peter", "Two Peter") \
+            .replace("2 John", "Two John") \
+            .replace("3 John", "Three John") \
             .replace("Gen ", "Genesis ") \
             .replace("Ex ", "Exodus ") \
             .replace("Lev ", "Leviticus ") \
@@ -199,13 +148,53 @@ class Reference:
             .replace("2 Pet ", "Two Peter ") \
             .replace("Rev ", "Revelation ")
 
-        new_ref = cls.convert_numbered_books(new_ref, digit_to_alpha=False)
+        return ref
+
+    @classmethod
+    def clean_reference(cls, ref):
+        ref = " ".join(ref.split()) # Multiple Whitespaces -> One Whitespace
+        ref = ref.strip().lower().title()
+
+        new_ref = ""
+        prev_char = ""
+        for i, char in enumerate(ref):
+            next_char = ref[min(len(ref)-1, i+1)]
+            # Insert Space After Book Name and Before Chapter/Verse Number
+            if char.isdigit() and prev_char.isalpha():
+                new_ref += " "
+
+            # Insert Space After Verse Number and Before Second Book Name
+            elif char.isalpha() and prev_char.isdigit():
+                new_ref += " "
+
+            # Insert Space Between Number and "-"
+            elif char == "-" and prev_char != " " and prev_char != "":
+                new_ref += " "
+
+            # Insert Space Between "-" and Number/Book
+            elif prev_char == "-" and char != " ":
+                new_ref += " "
+
+            elif char == " ":
+                # Remove Space Before ":" and After Chapter Number
+                if prev_char.isdigit() and next_char == ":":
+                    prev_char = ref[max(0, i)]
+                    continue
+                # Remove Space After ":" and Before Verse Number
+                elif prev_char == ":" and next_char.isdigit():
+                    prev_char = ref[max(0, i)]
+                    continue
+
+            prev_char = ref[max(0, i)]
+            new_ref += ref[i]
+
+        new_ref = cls.reference_replacements(new_ref)
 
         return new_ref
 
     @classmethod
     def interpret_reference(cls, ref):
-        ref = cls.convert_numbered_books(ref, digit_to_alpha=True)
+        ref = cls.clean_reference(ref)
 
         # Handle a Single Whole Book Reference [Genesis]
         if ref in Reverse_Bible_Books:
@@ -348,34 +337,66 @@ class Reference:
             if len(Bible[self.book_start]) == 1:
                 # Single Verse? - No "-"
                 if self.verse_start == self.verse_end:
-                    return f"{Bible_Books[self.book_start]} {self.verse_start + 1}"
+                    return (
+                        f"{Bible_Books[self.book_start]} "
+                        f"{self.verse_start + 1}"
+                    )
                 # Multiple Verses - Yes "-"
                 else:
-                    return f"{Bible_Books[self.book_start]} {self.verse_start + 1}-{self.verse_end + 1}"
+                    return (
+                        f"{Bible_Books[self.book_start]} "
+                        f"{self.verse_start + 1}-{self.verse_end + 1}"
+                    )
             # Multi Chapter Book - Yes ":"s
             else:
                 # Reference Contained in 1 Chapter? - Only 1 ":"
                 if self.chapter_start == self.chapter_end:
                     # Reference is a Single Verse? - No "-"
                     if self.verse_start == self.verse_end:
-                        return f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:{self.verse_start + 1}"
+                        return (
+                            f"{Bible_Books[self.book_start]} "
+                            f"{self.chapter_start + 1}:{self.verse_start + 1}"
+                        )
                     # Reference is Multiple Verses - Yes "-"
                     else:
-                        return f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:{self.verse_start + 1}-{self.verse_end + 1}"
+                        return (
+                            f"{Bible_Books[self.book_start]} "
+                            f"{self.chapter_start + 1}:"
+                            f"{self.verse_start + 1}-{self.verse_end + 1}"
+                        )
                 # Reference Spread Over Multiple Chapters - 2 ":"s
                 else:
-                    return f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:{self.verse_start + 1}-{self.chapter_end + 1}:{self.verse_end + 1}"
+                    return (
+                        f"{Bible_Books[self.book_start]} "
+                        f"{self.chapter_start + 1}:{self.verse_start + 1}-"
+                        f"{self.chapter_end + 1}:{self.verse_end + 1}"
+                    )
         # Multiple Book Reference - Print Both Book Names
         else:
             # Both Books are Single Chapter Books? - No ":"s
             if len(Bible[self.book_start]) == 1 and len(Bible[self.book_end]) == 1:
-                return f"{Bible_Books[self.book_start]} {self.verse_start + 1} - {Bible_Books[self.book_end]} {self.verse_end + 1}"
+                return (
+                    f"{Bible_Books[self.book_start]} {self.verse_start + 1} "
+                    f"- {Bible_Books[self.book_end]} {self.verse_end + 1}"
+                )
             # Only First Book is a Single Chapter Book? - No ":" at Start
             elif len(Bible[self.book_start]) == 1:
-                return f"{Bible_Books[self.book_start]} {self.verse_start + 1} - {Bible_Books[self.book_end]} {self.chapter_end + 1}:{self.verse_end + 1}"
+                return (
+                    f"{Bible_Books[self.book_start]} {self.verse_start + 1} "
+                    f"- {Bible_Books[self.book_end]} {self.chapter_end + 1}:"
+                    f"{self.verse_end + 1}"
+                )
             # Only Last Book is a Single Chapter Book? - No ":" at End
             elif len(Bible[self.book_end]) == 1:
-                return f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:{self.verse_start + 1} - {Bible_Books[self.book_end]} {self.verse_end + 1}"
+                return (
+                    f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:"
+                    f"{self.verse_start + 1} - {Bible_Books[self.book_end]} "
+                    f"{self.verse_end + 1}"
+                )
             # Neither Book is a Single Chapter Book - Two ":"s
             else:
-                return f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:{self.verse_start + 1} - {Bible_Books[self.book_end]} {self.chapter_end + 1}:{self.verse_end + 1}"
+                return (
+                    f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:"
+                    f"{self.verse_start + 1} - {Bible_Books[self.book_end]} "
+                    f"{self.chapter_end + 1}:{self.verse_end + 1}"
+                )

--- a/src/reference.py
+++ b/src/reference.py
@@ -31,9 +31,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from src.exceptions import InvalidReference
-from src.enums import Reverse_Bible_Books
 from src.enums import Bible
+from src.enums import Bible_Books
+from src.enums import Reverse_Bible_Books
+from src.exceptions import InvalidReference
 
 
 class Reference:
@@ -43,12 +44,12 @@ class Reference:
             self.ref_str = ""
         else:
             self.empty = False
-            self.ref_str = self.clean_reference(reference)
 
             self.book_start, self.chapter_start, self.verse_start, \
             self.book_end, self.chapter_end, self.verse_end = \
-                self.interpret_reference(self.ref_str)
+                self.interpret_reference(self.clean_reference(reference))
 
+            self.ref_str = self.standardize_reference()
 
     @staticmethod
     def convert_numbered_books(ref, digit_to_alpha):
@@ -81,11 +82,13 @@ class Reference:
 
     @classmethod
     def clean_reference(cls, ref):
+        ref = " ".join(ref.split()) # Multiple Whitespaces -> One Whitespace
         ref = ref.strip().lower().title()
 
         ref = cls.convert_numbered_books(ref, digit_to_alpha=True)
         # Replace "Psalm" -> "Psalms" will also turn "Psalms" -> "Psalmss"
         ref = ref \
+            .replace(".", "") \
             .replace("Psalm", "Psalms") \
             .replace("First", "One") \
             .replace("Second", "Two") \
@@ -124,6 +127,77 @@ class Reference:
 
             prev_char = ref[max(0, i)]
             new_ref += ref[i]
+
+        new_ref = new_ref \
+            .replace("Gen ", "Genesis ") \
+            .replace("Ex ", "Exodus ") \
+            .replace("Lev ", "Leviticus ") \
+            .replace("Num ", "Numbers ") \
+            .replace("Deut ", "Deuteronomy ") \
+            .replace("Josh ", "Joshua ") \
+            .replace("Judg ", "Judges ") \
+            .replace("1Sam ", "One Samuel ") \
+            .replace("1sam ", "One Samuel ") \
+            .replace("1 Sam ", "One Samuel ") \
+            .replace("2Sam ", "Two Samuel ") \
+            .replace("2sam ", "Two Samuel ") \
+            .replace("2 Sam ", "Two Samuel ") \
+            .replace("1Chron ", "One Chronicles ") \
+            .replace("1chron ", "One Chronicles ") \
+            .replace("1 Chron ", "One Chronicles ") \
+            .replace("Neh ", "Nehemiah ") \
+            .replace("Est ", "Esther ") \
+            .replace("Ps ", "Psalms ") \
+            .replace("Prov ", "Proverbs ") \
+            .replace("Eccles ", "Ecclesiastes ") \
+            .replace("Song ", "Song of Songs ") \
+            .replace("Isa ", "Isaiah ") \
+            .replace("Jer ", "Jeremiah ") \
+            .replace("Lam ", "Lamentations ") \
+            .replace("Ezek ", "Ezekiel ") \
+            .replace("Dan ", "Daniel ") \
+            .replace("Hos ", "Hosea ") \
+            .replace("Obad ", "Obadiah ") \
+            .replace("Mic ", "Micah ") \
+            .replace("Nah ", "Nahum ") \
+            .replace("Hab ", "Habakkuk ") \
+            .replace("Zeph ", "Zephaniah ") \
+            .replace("Hag ", "Haggai ") \
+            .replace("Zech ", "Zechariah ") \
+            .replace("Mal ", "Malachi ") \
+            .replace("Matt ", "Matthew ") \
+            .replace("Rom ", "Romans ") \
+            .replace("1Cor ", "One Corinthians ") \
+            .replace("1cor ", "One Corinthians ") \
+            .replace("1 Cor ", "One Corinthians ") \
+            .replace("2Cor ", "Two Corinthians ") \
+            .replace("2cor ", "Two Corinthians ") \
+            .replace("2 Cor ", "Two Corinthians ") \
+            .replace("Gal ", "Galatians ") \
+            .replace("Eph ", "Ephesians ") \
+            .replace("Phil ", "Philippians ") \
+            .replace("Col ", "Colossians ") \
+            .replace("1Thess ", "One Thessalonians ") \
+            .replace("1thess ", "One Thessalonians ") \
+            .replace("1 Thess ", "One Thessalonians ") \
+            .replace("2Thess ", "Two Thessalonians ") \
+            .replace("2thess ", "Two Thessalonians ") \
+            .replace("2 Thess ", "Two Thessalonians ") \
+            .replace("1Tim ", "One Timothy ") \
+            .replace("1tim ", "One Timothy ") \
+            .replace("1 Tim ", "One Timothy ") \
+            .replace("2Tim ", "Two Timothy ") \
+            .replace("2tim ", "Two Timothy ") \
+            .replace("2 Tim ", "Two Timothy ") \
+            .replace("Philem ", "Philemon ") \
+            .replace("Heb ", "Hebrews ") \
+            .replace("1Pet ", "One Peter ") \
+            .replace("1pet ", "One Peter ") \
+            .replace("1 Pet ", "One Peter ") \
+            .replace("2Pet ", "Two Peter ") \
+            .replace("2pet ", "Two Peter ") \
+            .replace("2 Pet ", "Two Peter ") \
+            .replace("Rev ", "Revelation ")
 
         new_ref = cls.convert_numbered_books(new_ref, digit_to_alpha=False)
 
@@ -266,3 +340,42 @@ class Reference:
                 raise InvalidReference(ref)
 
         return book_start, chapter_start, verse_start, book_end, chapter_end, verse_end
+
+    def standardize_reference(self):
+        # Single Book Reference? - Only Print Book Name Once
+        if self.book_start == self.book_end:
+            # Single Chapter Book? - No ":"s
+            if len(Bible[self.book_start]) == 1:
+                # Single Verse? - No "-"
+                if self.verse_start == self.verse_end:
+                    return f"{Bible_Books[self.book_start]} {self.verse_start + 1}"
+                # Multiple Verses - Yes "-"
+                else:
+                    return f"{Bible_Books[self.book_start]} {self.verse_start + 1}-{self.verse_end + 1}"
+            # Multi Chapter Book - Yes ":"s
+            else:
+                # Reference Contained in 1 Chapter? - Only 1 ":"
+                if self.chapter_start == self.chapter_end:
+                    # Reference is a Single Verse? - No "-"
+                    if self.verse_start == self.verse_end:
+                        return f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:{self.verse_start + 1}"
+                    # Reference is Multiple Verses - Yes "-"
+                    else:
+                        return f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:{self.verse_start + 1}-{self.verse_end + 1}"
+                # Reference Spread Over Multiple Chapters - 2 ":"s
+                else:
+                    return f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:{self.verse_start + 1}-{self.chapter_end + 1}:{self.verse_end + 1}"
+        # Multiple Book Reference - Print Both Book Names
+        else:
+            # Both Books are Single Chapter Books? - No ":"s
+            if len(Bible[self.book_start]) == 1 and len(Bible[self.book_end]) == 1:
+                return f"{Bible_Books[self.book_start]} {self.verse_start + 1} - {Bible_Books[self.book_end]} {self.verse_end + 1}"
+            # Only First Book is a Single Chapter Book? - No ":" at Start
+            elif len(Bible[self.book_start]) == 1:
+                return f"{Bible_Books[self.book_start]} {self.verse_start + 1} - {Bible_Books[self.book_end]} {self.chapter_end + 1}:{self.verse_end + 1}"
+            # Only Last Book is a Single Chapter Book? - No ":" at End
+            elif len(Bible[self.book_end]) == 1:
+                return f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:{self.verse_start + 1} - {Bible_Books[self.book_end]} {self.verse_end + 1}"
+            # Neither Book is a Single Chapter Book - Two ":"s
+            else:
+                return f"{Bible_Books[self.book_start]} {self.chapter_start + 1}:{self.verse_start + 1} - {Bible_Books[self.book_end]} {self.chapter_end + 1}:{self.verse_end + 1}"

--- a/src/verse.py
+++ b/src/verse.py
@@ -41,7 +41,7 @@ class Verse:
         self.book = book
         self.chapter = chapter
         self.verse = verse
-        self.reference = Reference(f"{Bible_Books.get(self.book, None)} {self.chapter+1}:{self.verse+1}")
+        self.reference = Reference(f"{Bible_Books[self.book]} {self.chapter + 1}:{self.verse + 1}")
         self.valid = self.validate(self)
 
         self.initialized = text is not None

--- a/test/test_passage.py
+++ b/test/test_passage.py
@@ -181,7 +181,7 @@ class PassageTests(BaseTest):
         'you. \nBlessed be the God and Father of our Lord Jesus Christ! ' + \
         'According to his great mercy, he has caused us to be born again to a ' + \
         'living hope through the resurrection of Jesus Christ from the dead, ' + \
-        '- 1 Peter 1:2 - 1:3'
+        '- 1 Peter 1:2-3'
 
         expected_full = '[2] according to the foreknowledge of God the Father, ' + \
         'in the sanctification of the Spirit, for obedience to Jesus Christ and ' + \
@@ -189,7 +189,7 @@ class PassageTests(BaseTest):
         'you. \n[3] Blessed be the God and Father of our Lord Jesus Christ! ' + \
         'According to his great mercy, he has caused us to be born again to a ' + \
         'living hope through the resurrection of Jesus Christ from the dead, ' + \
-        '- 1 Peter 1:2 - 1:3'
+        '- 1 Peter 1:2-3'
 
         passage.populate()
 

--- a/test/test_reference.py
+++ b/test/test_reference.py
@@ -31,7 +31,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import pdb
 from test.test_base import BaseTest
 from src.reference import Reference
 from src.exceptions import InvalidReference

--- a/test/test_reference.py
+++ b/test/test_reference.py
@@ -31,6 +31,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import pdb
 from test.test_base import BaseTest
 from src.reference import Reference
 from src.exceptions import InvalidReference
@@ -40,7 +41,7 @@ class ReferenceTests(BaseTest):
     """
     Test the Reference Object
     """
-    def test_clean_reference(self):
+    def test_standardize_reference(self):
         """
         Can reference strings be standardized?
         """
@@ -54,30 +55,85 @@ class ReferenceTests(BaseTest):
         ref2 = Reference(verse_string2)
         self.assertEqual(ref2.ref_str, expected_string2)
 
-        verse_string3 = "exodus 1-2"
-        expected_string3 = "Exodus 1 - 2"
+        verse_string3 = "exodus 1 -   2"
+        expected_string3 = "Exodus 1:1-2:25"
         ref3 = Reference(verse_string3)
         self.assertEqual(ref3.ref_str, expected_string3)
 
         verse_string4 = "First Peter - 2 peter 1 : 5"
-        expected_string4 = "1 Peter - 2 Peter 1:5"
+        expected_string4 = "1 Peter 1:1 - 2 Peter 1:5"
         ref4 = Reference(verse_string4)
         self.assertEqual(ref4.ref_str, expected_string4)
 
         verse_string5 = "psalm-proverbs"
-        expected_string5 = "Psalms - Proverbs"
+        expected_string5 = "Psalms 1:1 - Proverbs 31:31"
         ref5 = Reference(verse_string5)
         self.assertEqual(ref5.ref_str, expected_string5)
 
         verse_string6 = "Ezra 1 : 2-2 : 1"
-        expected_string6 = "Ezra 1:2 - 2:1"
+        expected_string6 = "Ezra 1:2-2:1"
         ref6 = Reference(verse_string6)
         self.assertEqual(ref6.ref_str, expected_string6)
 
         verse_string7 = "First Peter - 2 peter 1 : 5"
-        expected_string7 = "1 Peter - 2 Peter 1:5"
+        expected_string7 = "1 Peter 1:1 - 2 Peter 1:5"
         ref7 = Reference(verse_string7)
         self.assertEqual(ref7.ref_str, expected_string7)
+
+        verse_string8 = "First Peter 1:1 - 1 peter 1 : 5"
+        expected_string8 = "1 Peter 1:1-5"
+        ref8 = Reference(verse_string8)
+        self.assertEqual(ref8.ref_str, expected_string8)
+
+        verse_string9 = "1 Peter 1:1 - 1 : 5"
+        expected_string9 = "1 Peter 1:1-5"
+        ref9 = Reference(verse_string9)
+        self.assertEqual(ref9.ref_str, expected_string9)
+
+        verse_string10 = "1 Peter 1:1 - 2 peter 1 : 5"
+        expected_string10 = "1 Peter 1:1 - 2 Peter 1:5"
+        ref10 = Reference(verse_string10)
+        self.assertEqual(ref10.ref_str, expected_string10)
+
+        verse_string11 = "1pet1:1 -2 pet 1 : 5"
+        expected_string11 = "1 Peter 1:1 - 2 Peter 1:5"
+        ref11 = Reference(verse_string11)
+        self.assertEqual(ref11.ref_str, expected_string11)
+
+        verse_string12 = "philem 10 - pHiLeM 11"
+        expected_string12 = "Philemon 10-11"
+        ref12 = Reference(verse_string12)
+        self.assertEqual(ref12.ref_str, expected_string12)
+
+        verse_string13 = "First  Peter -  2  peter  1  :  5"
+        expected_string13 = "1 Peter 1:1 - 2 Peter 1:5"
+        ref13 = Reference(verse_string13)
+        self.assertEqual(ref13.ref_str, expected_string13)
+
+        verse_string14 = "1 Peter 1:1 - 2 : 5"
+        expected_string14 = "1 Peter 1:1-2:5"
+        ref14 = Reference(verse_string14)
+        self.assertEqual(ref14.ref_str, expected_string14)
+
+        verse_string15 = "1Peter1:1 - 2 : 5"
+        expected_string15 = "1 Peter 1:1-2:5"
+        ref15 = Reference(verse_string15)
+        self.assertEqual(ref15.ref_str, expected_string15)
+
+        verse_string16 = "Obadiah 5 - Jude 20"
+        expected_string16 = "Obadiah 5 - Jude 20"
+        ref16 = Reference(verse_string16)
+        self.assertEqual(ref16.ref_str, expected_string16)
+
+        verse_string17 = "Obadiah5-Jonah2:2"
+        expected_string17 = "Obadiah 5 - Jonah 2:2"
+        ref17 = Reference(verse_string17)
+        self.assertEqual(ref17.ref_str, expected_string17)
+
+        verse_string18 = "1 John 1:1 - 2 John 13"
+        expected_string18 = "1 John 1:1 - 2 John 13"
+        ref18 = Reference(verse_string18)
+        self.assertEqual(ref18.ref_str, expected_string18)
 
     def test_interpret_reference(self):
         """


### PR DESCRIPTION
Now regardless of how you specify the reference, if it is recognized by `scripture_phaser`, it will be mapped to a unique reference string.