### PR TITLE
Fixed Fast Mode with Random Single Verse Bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src"]
 
 [project]
 name = "scripture_phaser"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	"meaningless==1.0.0",
 	"peewee==3.17.0",

--- a/src/cli.py
+++ b/src/cli.py
@@ -376,7 +376,14 @@ class CLI:
 
     def fast_recitation(self, ref):
         ans = self.api.get_fast_recitation_ans(ref)
-        passage_words = self.api.passage.show().split()
+        if self.api.random_single_verse:
+            # @@@ TODO: The API should be able to pull a verse by reference
+            for verse in self.api.passage.verses:
+                if verse.reference.ref_str == ref.ref_str:
+                    passage_words = verse.text.split()
+                    break
+        else:
+            passage_words = self.api.passage.show().split()
 
         self.clear()
         print(f"[{TC.CYAN}{ref.ref_str}{TC.WHITE}]")

--- a/src/enums.py
+++ b/src/enums.py
@@ -36,8 +36,8 @@ import enum
 import platform
 from pathlib import Path
 
-VERSION = "1.1.0"
-RELEASE_DATE = "2024-03-24"
+VERSION = "1.1.1"
+RELEASE_DATE = "2024-03-27"
 
 if platform.system() == "Windows":
     CONFIG_DIR = Path(os.environ["HOMEPATH"]) / ".config"


### PR DESCRIPTION
There was a bug where if you tried to recite a verse in Fast Mode with Random Single Verse on, the previewed verse at the top of the screen would always be the first first in the reference, not necessarily the random verse selected for recitation. This change fixes that.