### PR TITLE
1.2.1 Release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src"]
 
 [project]
 name = "scripture_phaser"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
 	"meaningless==1.0.0",
 	"peewee==3.17.0",

--- a/src/cli.py
+++ b/src/cli.py
@@ -157,12 +157,12 @@ class CLISTR:
     def ALL_VERSES_RANKED(self):
         verse_scores, verse_counts = self.api.stats.all_verses_ranked()
 
-        # Used to Make Output Columnar
-        max_attempt_width = len(str(max(verse_counts.values())))
-
         if len(verse_counts) == 0:
             string = "You haven't recorded any attempts yet!"
         else:
+            # Used to Make Output Columnar
+            max_attempt_width = len(str(max(verse_counts.values())))
+
             string = ""
             sorted_verses = sorted(verse_scores.items(), key=lambda item: item[1], reverse=True)
             for ref, score in sorted_verses:

--- a/src/enums.py
+++ b/src/enums.py
@@ -36,8 +36,8 @@ import enum
 import platform
 from pathlib import Path
 
-VERSION = "1.2.0"
-RELEASE_DATE = "2024-04-01"
+VERSION = "1.2.1"
+RELEASE_DATE = "2024-04-02"
 
 if platform.system() == "Windows":
     CONFIG_DIR = Path(os.environ["HOMEPATH"]) / ".config"


### PR DESCRIPTION
Calling the stats would crash if there were no recorded attempts. This is now fixed.